### PR TITLE
SMU Source Range and Measure Range for bias,step,sweep AUTO by default

### DIFF
--- a/script-gen-manager/src/instr_metadata/msmu60_metadata.rs
+++ b/script-gen-manager/src/instr_metadata/msmu60_metadata.rs
@@ -35,8 +35,8 @@ impl Msmu60Metadata {
             ],
         );
 
-        base.add_default("source_meas.range.defaultv", "2 V");
-        base.add_default("source_meas.range.defaulti", "100 mA");
+        base.add_default("source_meas.range.defaultv", "AUTO");
+        base.add_default("source_meas.range.defaulti", "AUTO");
 
         // Add ranges
         base.add_range("source.levelv".to_string(), -60.0, 60.0);


### PR DESCRIPTION
This PR has changes made for source range and measure range for bias, step and sweep to be AUTO by default. 