### PR TITLE
Allow SMU Source Voltage/Current for Overrange Case

### DIFF
--- a/script-gen-manager/src/instr_metadata/msmu60_metadata.rs
+++ b/script-gen-manager/src/instr_metadata/msmu60_metadata.rs
@@ -39,8 +39,8 @@ impl Msmu60Metadata {
         base.add_default("source_meas.range.defaulti", "AUTO");
 
         // Add ranges
-        base.add_range("source.levelv".to_string(), -60.0, 60.0);
-        base.add_range("source.leveli".to_string(), -1.5, 1.5);
+        base.add_range("source.levelv".to_string(), -60.6, 60.6);
+        base.add_range("source.leveli".to_string(), -1.515, 1.515);
 
         // Add region maps
         // when pulse mode is off

--- a/script-gen-manager/src/model/chan_data/channel_range.rs
+++ b/script-gen-manager/src/model/chan_data/channel_range.rs
@@ -44,11 +44,12 @@ impl ChannelRange {
         } else {
             let scaled_value = self.get_scaled_value();
             if let Some(scaled_value) = scaled_value {
-                if result < -scaled_value {
-                    return -scaled_value;
-                } else if result > scaled_value {
-                    return scaled_value;
-                }
+                let overrange_scaled_value = scaled_value *1.01;
+                if result < -overrange_scaled_value {
+                    return -overrange_scaled_value;
+                } else if result > overrange_scaled_value {
+                    return overrange_scaled_value;
+                } 
             }
         }
         //TODO: error handling?


### PR DESCRIPTION
For MSMU60-2, source voltage and current should allow source values 1% above the range. This PR has changes made to include the overrange scenarios.