### PR TITLE
MPSU50-2ST source voltage overrange case

### DIFF
--- a/script-gen-manager/src/instr_metadata/base_metadata.rs
+++ b/script-gen-manager/src/instr_metadata/base_metadata.rs
@@ -17,6 +17,7 @@ pub trait Metadata: Debug + Clone {
     fn get_default(&self, key: &str) -> Option<&'static str>;
     fn get_name(&self, key: &str) -> Option<&'static str>;
     fn get_region_map(&self, key: &str) -> Option<RegionMapMetadata>;
+    fn get_overrange_scale(&self) -> f64;
 }
 
 /// A struct that holds base metadata information common to all Trebuchet instruments.
@@ -27,6 +28,7 @@ pub struct BaseMetadata {
     defaults: HashMap<&'static str, &'static str>,
     names: HashMap<&'static str, &'static str>,
     region_maps: HashMap<&'static str, RegionMapMetadata>,
+    overrange_scale: f64,
 }
 
 impl BaseMetadata {
@@ -65,6 +67,7 @@ impl BaseMetadata {
         let defaults = HashMap::new();
         let mut names = HashMap::new();
         let region_maps = HashMap::new();
+        let overrange_scale = 1.0;
 
         //timing: source or measure delay type
         options.insert(
@@ -85,6 +88,7 @@ impl BaseMetadata {
             defaults,
             names,
             region_maps,
+            overrange_scale,
         }
     }
 
@@ -102,6 +106,10 @@ impl BaseMetadata {
 
     pub fn add_region_map(&mut self, key: &'static str, region_map_metadata: RegionMapMetadata) {
         self.region_maps.insert(key, region_map_metadata);
+    }
+
+    pub fn add_overrange_scale(&mut self, scale: f64) {
+        self.overrange_scale = scale;
     }
 }
 
@@ -126,6 +134,10 @@ impl Metadata for BaseMetadata {
 
     fn get_region_map(&self, key: &str) -> Option<RegionMapMetadata> {
         self.region_maps.get(key).cloned()
+    }
+
+    fn get_overrange_scale(&self) -> f64 {
+        self.overrange_scale
     }
 }
 

--- a/script-gen-manager/src/instr_metadata/mpsu50_metadata.rs
+++ b/script-gen-manager/src/instr_metadata/mpsu50_metadata.rs
@@ -22,7 +22,7 @@ impl Mpsu50Metadata {
 
         //TODO: verify for Trebuchet PSU (model: MPSU50-2ST)
         // Add ranges
-        base.add_range("source.levelv".to_string(), -50.0, 50.0);
+        base.add_range("source.levelv".to_string(), -50.1, 50.1);
         base.add_range("source.leveli".to_string(), -5.0, 5.0);
 
         base.add_range("source.limiti".to_string(), 0.01, 5.1);
@@ -36,6 +36,8 @@ impl Mpsu50Metadata {
         region_map_metadata.add_region(1, 0.0, 0.0, -10.0, -5.0);
         region_map_metadata.add_region(1, 0.0, 0.0, -50.0, -1.0);
         base.add_region_map("psu.region", region_map_metadata);
+
+        base.add_overrange_scale(1.002);
 
         Mpsu50Metadata {
             base,
@@ -63,5 +65,9 @@ impl Metadata for Mpsu50Metadata {
 
     fn get_region_map(&self, key: &str) -> Option<RegionMapMetadata> {
         self.base.get_region_map(key)
+    }
+
+    fn get_overrange_scale(&self) -> f64 {
+        self.base.get_overrange_scale()
     }
 }

--- a/script-gen-manager/src/instr_metadata/msmu60_metadata.rs
+++ b/script-gen-manager/src/instr_metadata/msmu60_metadata.rs
@@ -39,8 +39,8 @@ impl Msmu60Metadata {
         base.add_default("source_meas.range.defaulti", "AUTO");
 
         // Add ranges
-        base.add_range("source.levelv".to_string(), -60.0, 60.0);
-        base.add_range("source.leveli".to_string(), -1.5, 1.5);
+        base.add_range("source.levelv".to_string(), -60.6, 60.6);
+        base.add_range("source.leveli".to_string(), -1.515, 1.515);
 
         // Add region maps
         // when pulse mode is off

--- a/script-gen-manager/src/instr_metadata/msmu60_metadata.rs
+++ b/script-gen-manager/src/instr_metadata/msmu60_metadata.rs
@@ -55,6 +55,8 @@ impl Msmu60Metadata {
         region_map_metadata.add_region(1, -20.0, -1.5, 20.0, 1.5);
         base.add_region_map("smu.region", region_map_metadata);
 
+        base.add_overrange_scale(1.01);
+
         Msmu60Metadata {
             base,
             // Initialize additional properties
@@ -81,5 +83,9 @@ impl Metadata for Msmu60Metadata {
 
     fn get_region_map(&self, key: &str) -> Option<RegionMapMetadata> {
         self.base.get_region_map(key)
+    }
+
+    fn get_overrange_scale(&self) -> f64 {
+        self.base.get_overrange_scale()
     }
 }

--- a/script-gen-manager/src/model/chan_data/channel_range.rs
+++ b/script-gen-manager/src/model/chan_data/channel_range.rs
@@ -44,11 +44,12 @@ impl ChannelRange {
         } else {
             let scaled_value = self.get_scaled_value();
             if let Some(scaled_value) = scaled_value {
-                if result < -scaled_value {
-                    return -scaled_value;
-                } else if result > scaled_value {
-                    return scaled_value;
-                }
+                let overrange_scaled_value = scaled_value *1.01;
+                if result < -overrange_scaled_value {
+                    return -overrange_scaled_value;
+                } else if result > overrange_scaled_value {
+                    return overrange_scaled_value;
+                } 
             }
         }
         //TODO: error handling?

--- a/script-gen-manager/src/model/chan_data/channel_range.rs
+++ b/script-gen-manager/src/model/chan_data/channel_range.rs
@@ -44,12 +44,12 @@ impl ChannelRange {
         } else {
             let scaled_value = self.get_scaled_value();
             if let Some(scaled_value) = scaled_value {
-                let overrange_scaled_value = scaled_value *1.01;
+                let overrange_scaled_value = scaled_value * 1.01;
                 if result < -overrange_scaled_value {
                     return -overrange_scaled_value;
                 } else if result > overrange_scaled_value {
                     return overrange_scaled_value;
-                } 
+                }
             }
         }
         //TODO: error handling?

--- a/script-gen-manager/src/model/chan_data/channel_range.rs
+++ b/script-gen-manager/src/model/chan_data/channel_range.rs
@@ -12,6 +12,8 @@ pub struct ChannelRange {
     pub min: f64,
     #[serde(skip)]
     pub max: f64,
+    #[serde(skip)]
+    pub overrange_scale: f64,
 }
 
 impl ChannelRange {
@@ -22,6 +24,7 @@ impl ChannelRange {
             unit: String::new(),
             min: 0.0,
             max: 0.0,
+            overrange_scale: 1.0,
         }
     }
 
@@ -31,6 +34,10 @@ impl ChannelRange {
 
     pub fn set_max(&mut self, max: f64) {
         self.max = max;
+    }
+
+    pub fn set_overrange_scale(&mut self, scale: f64) {
+        self.overrange_scale = scale;
     }
 
     pub fn limit(&mut self, value: f64) -> f64 {
@@ -44,7 +51,7 @@ impl ChannelRange {
         } else {
             let scaled_value = self.get_scaled_value();
             if let Some(scaled_value) = scaled_value {
-                let overrange_scaled_value = scaled_value * 1.01;
+                let overrange_scaled_value = scaled_value * self.overrange_scale;
                 if result < -overrange_scaled_value {
                     return -overrange_scaled_value;
                 } else if result > overrange_scaled_value {

--- a/script-gen-manager/src/model/chan_data/default_channel.rs
+++ b/script-gen-manager/src/model/chan_data/default_channel.rs
@@ -107,6 +107,7 @@ impl CommonChanAttributes {
         self.set_source_range(&device_metadata);
         self.set_source_range_limits(&device_metadata);
         self.set_source_range_value();
+        self.set_overrange_scale(&device_metadata);
         self.validate_source_limits(&device_metadata);
     }
 
@@ -130,6 +131,11 @@ impl CommonChanAttributes {
             self.source_range.set_min(min);
             self.source_range.set_max(max);
         }
+    }
+
+    fn set_overrange_scale(&mut self, metadata: &MetadataEnum) {
+        let scale = self.get_overrange_scale(metadata);
+        self.source_range.set_overrange_scale(scale);
     }
 
     fn set_source_range_value(&mut self) {
@@ -211,6 +217,14 @@ impl CommonChanAttributes {
             MetadataEnum::Base(base_metadata) => base_metadata.get_range(key),
             MetadataEnum::Msmu60(msmu60_metadata) => msmu60_metadata.get_range(key),
             MetadataEnum::Mpsu50(mpsu50_metadata) => mpsu50_metadata.get_range(key),
+        }
+    }
+
+    fn get_overrange_scale(&self, metadata: &MetadataEnum) -> f64 {
+        match metadata {
+            MetadataEnum::Base(base_metadata) => base_metadata.get_overrange_scale(),
+            MetadataEnum::Msmu60(msmu60_metadata) => msmu60_metadata.get_overrange_scale(),
+            MetadataEnum::Mpsu50(mpsu50_metadata) => mpsu50_metadata.get_overrange_scale(),
         }
     }
 


### PR DESCRIPTION
Allow user to set voltage till 50.1V for MPSU50-2ST. This PR also includes code enhancements to handle overrange scenarios for both SMU and PSU.