### PR TITLE
fix/TSP-1906-Correct spelling of MSMU200-2

### DIFF
--- a/script-gen-ui/src/app/components/empty-config/empty-config.component.html
+++ b/script-gen-ui/src/app/components/empty-config/empty-config.component.html
@@ -5,7 +5,7 @@
   <br>
   • An MP5103 mainframe
   <br>
-  • Either MPSU50-2ST or MSMU60-2 or MSU200-2 modules installed in slots
+  • Either MPSU50-2ST or MSMU60-2 or MSMU200-2 modules installed in slots
   <br>
   • Located in the localnode or one of the TSP-Link nodes
 </p>


### PR DESCRIPTION
Correct the spelling of MSMU200-2 in the empty system configuration UI message.

Resolves [TSP-1906](https://jira.global.tektronix.net/jira/browse/TSP-1906)